### PR TITLE
Version bump

### DIFF
--- a/ext/libosrm/extconf.rb
+++ b/ext/libosrm/extconf.rb
@@ -50,7 +50,7 @@ else
         # The gem version constraint in the Rakefile is not respected at install time.
         # Keep this version in sync with the one in the Rakefile !
         require "rubygems"
-        gem "mini_portile2", "~> 2.3.0"
+        gem "mini_portile2", "~> 2.5.0"
         require "mini_portile2"
 
         # Current version doesn’t support out of tree builds

--- a/lib/libosrm/version.rb
+++ b/lib/libosrm/version.rb
@@ -1,5 +1,5 @@
 
 
 module LibOSRM
-  VERSION = "1.0.0-rc2"
+  VERSION = "1.0.0-rc3"
 end

--- a/libosrm.gemspec
+++ b/libosrm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "> 2.3.0"
 
-  s.add_runtime_dependency      "mini_portile2",  "~> 2.3"
+  s.add_runtime_dependency      "mini_portile2",  "~> 2.5"
   s.add_runtime_dependency      "rice",           "~> 2.1"
   s.add_development_dependency  "rake",           "~> 12.0"
   s.add_development_dependency  "rake-compiler",  "~> 1.0"


### PR DESCRIPTION
At the moment, this gem can't be installed because mini_portile 2.3 no longer exists. This PR bumps it up to 2.5, the latest available version.